### PR TITLE
Remove dependence on .Net V7.3 language features

### DIFF
--- a/efi-no-runtime/zerosharp.cs
+++ b/efi-no-runtime/zerosharp.cs
@@ -118,7 +118,7 @@ namespace System.Runtime.InteropServices
 [System.Runtime.InteropServices.McgIntrinsicsAttribute]
 internal class RawCalliHelper
 {
-    public static unsafe void StdCall<T, U>(IntPtr pfn, T* arg1, U* arg2) where T : unmanaged where U : unmanaged
+    public static unsafe void StdCall(IntPtr pfn, byte* arg1, char* arg2)
     {
         // This will be filled in by an IL transform
     }


### PR DESCRIPTION
unmanaged type constraint is a .Net V7.3 language feature which does not appear to currently be generally available. This change allows the example to compile with language version 7.2 which is available with Microsoft Visual Studio 2017