### PR TITLE
Add missing pointer to EEType

### DIFF
--- a/efi-no-runtime/zerosharp.cs
+++ b/efi-no-runtime/zerosharp.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace System
 {
-    public class Object { }
+    public class Object { public IntPtr m_pEEType; } // The layout of object is a contract with the compiler.
     public struct Void { }
     public struct Boolean { }
     public struct Char { }


### PR DESCRIPTION
This give me bunch of pulling hairs, while I copy that `no runtime` implementation. `String.Length` was not working without that 😄 

This report and your blog post likely provide documentation for CoreRT, so I think it can be beneficial to fix that.