### PR TITLE
Fix unmanaged in the efinoruntime project

### DIFF
--- a/efi-no-runtime/efinoruntime.csproj
+++ b/efi-no-runtime/efinoruntime.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>9.0</LangVersion>
 
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <IlcInvariantGlobalization>true</IlcInvariantGlobalization>

--- a/efi-no-runtime/zerosharp.cs
+++ b/efi-no-runtime/zerosharp.cs
@@ -41,7 +41,7 @@ namespace System
             public static unsafe int OffsetToStringData => sizeof(IntPtr) + sizeof(int);
         }
 
-        public class RuntimeFeature
+        public static class RuntimeFeature
         {
             public const string UnmanagedSignatureCallingConvention = nameof(UnmanagedSignatureCallingConvention);
         }


### PR DESCRIPTION
Roslyn is very particular about the shape of the `RuntimeFeature` class: it must be both in the assembly that defines System.Object _and_ be a `static` class. Just a class doesn't cut it. I also added LangVersion 9 to the project file to get rid of the langversion error when opening the csproj in VS or VSCode.
